### PR TITLE
Add BSD license to repository

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,9 @@
+BSD 3-Clause License
+
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/README.md
+++ b/README.md
@@ -345,3 +345,7 @@ This will list out all the packages installed, then need to search through to ma
   - Get better resolution when booted into console by adding `GRUB_GFXMODE=auto` in `/etc/default/grub`, then run `sudo update-grub`
 - [ ] Learn from [Wayland Apps in Wireguard Docker Containers](https://www.procustodibus.com/blog/2024/10/wayland-wireguard-containers/) and see if anything worth copying
 - [ ] [Dotfile managers](https://dotfiles.github.io/utilities/) might have something better than GNU `stow`
+
+## License
+
+This repository is licensed under the BSD 3-Clause License. See the LICENSE file for more information.


### PR DESCRIPTION
Add BSD 3-Clause License to the repository.

* **LICENSE**
  - Add a new file named `LICENSE` with the BSD 3-Clause License text.
* **README.md**
  - Add a new section at the end of the file mentioning the BSD license and referring to the LICENSE file for more information.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/fortes/dotfiles/pull/12?shareId=b815eb78-5a02-441a-9449-3344aa77e79e).