### PR TITLE
Harden stow wrapper with safe package handling

### DIFF
--- a/script/stow
+++ b/script/stow
@@ -13,16 +13,32 @@ main() {
   local dotfiles_root
   dotfiles_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
   local stowed_files_path="${dotfiles_root}/stowed-files"
+  local target_dir="${HOME}"
+
+  if ! command -v stow >/dev/null 2>&1; then
+    >&2 echo "Error: stow command not found. Please install GNU Stow first."
+    return 1
+  fi
 
   if [[ ! -d "${stowed_files_path}" ]]; then
     >&2 echo "Warning: stowed-files directory not found at ${stowed_files_path}, skipping stow"
     return 0
   fi
 
-  # Purposefully allow word splitting on $@ to pass through flags
-  # shellcheck disable=SC2046,SC2068
-  stow --dir="${stowed_files_path}/" --target="$HOME" \
-    $(ls "${stowed_files_path}") ${@}
+  local packages=()
+  local package_path
+  for package_path in "${stowed_files_path}"/*; do
+    [[ -d "${package_path}" ]] || continue
+    packages+=("$(basename "${package_path}")")
+  done
+
+  if [[ ${#packages[@]} -eq 0 ]]; then
+    >&2 echo "Warning: no packages found in ${stowed_files_path}, nothing to stow"
+    return 0
+  fi
+
+  stow --dir="${stowed_files_path}/" --target="${target_dir}" \
+    "${packages[@]}" "$@"
 }
 
 main "${@}"


### PR DESCRIPTION
## Summary\n- add an explicit check that stow (GNU Stow) version 2.4.1

SYNOPSIS:

    stow [OPTION ...] [-D|-S|-R] PACKAGE ... [-D|-S|-R] PACKAGE ...

OPTIONS:

    -d DIR, --dir=DIR     Set stow dir to DIR (default is current dir)
    -t DIR, --target=DIR  Set target to DIR (default is parent of stow dir)

    -S, --stow            Stow the package names that follow this option
    -D, --delete          Unstow the package names that follow this option
    -R, --restow          Restow (like stow -D followed by stow -S)

    --ignore=REGEX        Ignore files ending in this Perl regex
    --defer=REGEX         Don't stow files beginning with this Perl regex
                          if the file is already stowed to another package
    --override=REGEX      Force stowing files beginning with this Perl regex
                          if the file is already stowed to another package
    --adopt               (Use with care!)  Import existing files into stow package
                          from target.  Please read docs before using.
    --dotfiles            Enables special handling for dotfiles that are
                          Stow packages that start with "dot-" and not "."
    -p, --compat          Use legacy algorithm for unstowing

    -n, --no, --simulate  Do not actually make any filesystem changes
    -v, --verbose[=N]     Increase verbosity (levels are from 0 to 5;
                            -v or --verbose adds 1; --verbose=N sets level)
    -V, --version         Show stow version number
    -h, --help            Show this help

Report bugs to: bug-stow@gnu.org
Stow home page: <http://www.gnu.org/software/stow/>
General help using GNU software: <http://www.gnu.org/gethelp/> is installed before running\n- replace AGENTS.md
CLAUDE.md
Dockerfile
LICENSE
Makefile
README.md
TODO.md
docker-compose.yml
script
stowed-files-based package expansion with safe array handling\n- collect package basenames portably (works on macOS/BSD and GNU)\n- pass package names and CLI args safely to stow (GNU Stow) version 2.4.1

SYNOPSIS:

    stow [OPTION ...] [-D|-S|-R] PACKAGE ... [-D|-S|-R] PACKAGE ...

OPTIONS:

    -d DIR, --dir=DIR     Set stow dir to DIR (default is current dir)
    -t DIR, --target=DIR  Set target to DIR (default is parent of stow dir)

    -S, --stow            Stow the package names that follow this option
    -D, --delete          Unstow the package names that follow this option
    -R, --restow          Restow (like stow -D followed by stow -S)

    --ignore=REGEX        Ignore files ending in this Perl regex
    --defer=REGEX         Don't stow files beginning with this Perl regex
                          if the file is already stowed to another package
    --override=REGEX      Force stowing files beginning with this Perl regex
                          if the file is already stowed to another package
    --adopt               (Use with care!)  Import existing files into stow package
                          from target.  Please read docs before using.
    --dotfiles            Enables special handling for dotfiles that are
                          Stow packages that start with "dot-" and not "."
    -p, --compat          Use legacy algorithm for unstowing

    -n, --no, --simulate  Do not actually make any filesystem changes
    -v, --verbose[=N]     Increase verbosity (levels are from 0 to 5;
                            -v or --verbose adds 1; --verbose=N sets level)
    -V, --version         Show stow version number
    -h, --help            Show this help

Report bugs to: bug-stow@gnu.org
Stow home page: <http://www.gnu.org/software/stow/>
General help using GNU software: <http://www.gnu.org/gethelp/>\n- emit a warning when no stow packages are present\n\n## Why\nPR #21 had good intent but included non-portable and conflicting changes. This PR is a clean replacement with just the safe, cross-platform  improvements.\n\n## Validation\n- Checking bash syntax...
  Checking script/base16-default-dark.sh
  Checking script/base16-default-light.sh
  Checking script/check_health
  Checking script/cleanup_disk
  Checking script/create_local_profile
  Checking script/generate_completions
  Checking script/install_1password
  Checking script/install_cargo_packages
  Checking script/install_claude_code
  Checking script/install_et
  Checking script/install_github_packages
  Checking script/install_llm_plugins
  Checking script/install_node_packages
  Checking script/install_ollama
  Checking script/install_python_packages
  Checking script/install_signal
  Checking script/install_snap_packages
  Checking script/install_vscode_extensions
  Checking script/install_yazi_plugins
  Checking script/install_zerotier
  Checking script/lib.sh
  Checking script/lock_local_files
  Checking script/remove_default_dotfiles
  Checking script/set_default_browser
  Checking script/set_dotfiles_remote
  Checking script/setup
  Checking script/setup_linux
  Checking script/setup_mac
  Checking script/stow
All scripts have valid bash syntax!
Linting shell scripts...
  Checking script/base16-default-dark.sh
  Checking script/base16-default-light.sh
  Checking script/check_health
  Checking script/cleanup_disk
  Checking script/create_local_profile
  Checking script/generate_completions
  Checking script/install_1password
  Checking script/install_cargo_packages
  Checking script/install_claude_code
  Checking script/install_et
  Checking script/install_github_packages
  Checking script/install_llm_plugins
  Checking script/install_node_packages
  Checking script/install_ollama
  Checking script/install_python_packages
  Checking script/install_signal
  Checking script/install_snap_packages
  Checking script/install_vscode_extensions
  Checking script/install_yazi_plugins
  Checking script/install_zerotier
  Checking script/lib.sh
  Checking script/lock_local_files
  Checking script/remove_default_dotfiles
  Checking script/set_default_browser
  Checking script/set_dotfiles_remote
  Checking script/setup
  Checking script/setup_linux
  Checking script/setup_mac
  Checking script/stow
All scripts passed shellcheck!
Checking shell script formatting...